### PR TITLE
Add missing crossplane meta-crds and update README instructions.

### DIFF
--- a/crossplane/README.md
+++ b/crossplane/README.md
@@ -5,7 +5,8 @@
 ```
 kubectl create ns crossplane-system
 kubectl -n crossplane-system apply -f meta-crds/
-kubectl -n crossplane-system apply -f crossplane-v0.14.0.yaml
+kubectl -n crossplane-system apply -f crossplane-v0.14.0.yaml -f meta-crds/providerconfigs-crds
+
 ```
 
 ##### 2) Install crossplane AWS secret
@@ -44,8 +45,12 @@ kubectl -n crossplane-system get pods
 
 ```
 # NOTE: This requires the AWS IAM permissions listed in the example manifest!
+# It also takes a few mintues for the Crossplane AWS CRDs to finish installing.
+# Please rerun the `kubectl apply` listed below if you encounter a missing CRD 
+# error message the first time you run the command.
+
 kubectl -n crossplane-system apply -f aws-eks-example.yaml
 
 # Confirm EKS cluster is healthy
-kubectl -n crossplane-system desribe Cluster eks-cluster-001
+kubectl -n crossplane-system describe Cluster eks-cluster-001
 ```

--- a/crossplane/meta-crds/providerconfigs-crds/pkg.crossplane.io_aws_providerconfigs.yaml
+++ b/crossplane/meta-crds/providerconfigs-crds/pkg.crossplane.io_aws_providerconfigs.yaml
@@ -1,0 +1,145 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.0
+  name: providerconfigs.aws.crossplane.io
+spec:
+  conversion:
+    strategy: None
+  group: aws.crossplane.io
+  names:
+    categories:
+    - crossplane
+    - provider
+    - aws
+    kind: ProviderConfig
+    listKind: ProviderConfigList
+    plural: providerconfigs
+    singular: providerconfig
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    - jsonPath: .spec.credentialsSecretRef.name
+      name: SECRET-NAME
+      priority: 1
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: A ProviderConfig configures how AWS controllers will connect
+          to AWS API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: A ProviderConfigSpec defines the desired state of a ProviderConfig.
+            properties:
+              credentials:
+                description: Credentials required to authenticate to this provider.
+                properties:
+                  secretRef:
+                    description: A CredentialsSecretRef is a reference to a secret
+                      key that contains the credentials that must be used to connect
+                      to the provider.
+                    properties:
+                      key:
+                        description: The key to select.
+                        type: string
+                      name:
+                        description: Name of the secret.
+                        type: string
+                      namespace:
+                        description: Namespace of the secret.
+                        type: string
+                    required:
+                    - key
+                    - name
+                    - namespace
+                    type: object
+                  source:
+                    description: Source of the provider credentials.
+                    enum:
+                    - None
+                    - Secret
+                    - InjectedIdentity
+                    type: string
+                required:
+                - source
+                type: object
+            required:
+            - credentials
+            type: object
+          status:
+            description: A ProviderConfigStatus represents the status of a ProviderConfig.
+            properties:
+              conditions:
+                description: Conditions of the resource.
+                items:
+                  description: A Condition that may apply to a resource.
+                  properties:
+                    lastTransitionTime:
+                      description: LastTransitionTime is the last time this condition
+                        transitioned from one status to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A Message containing details about this condition's
+                        last transition from one status to another, if any.
+                      type: string
+                    reason:
+                      description: A Reason for this condition's last transition from
+                        one status to another.
+                      type: string
+                    status:
+                      description: Status of this condition; is it currently True,
+                        False, or Unknown?
+                      type: string
+                    type:
+                      description: Type of this condition. At most one of each condition
+                        type may apply to a resource at any point in time.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              users:
+                description: Users of this provider configuration.
+                format: int64
+                type: integer
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    categories:
+    - crossplane
+    - provider
+    - aws
+    kind: ProviderConfig
+    listKind: ProviderConfigList
+    plural: providerconfigs
+    singular: providerconfig
+  storedVersions:
+  - v1beta1

--- a/crossplane/meta-crds/providerconfigs-crds/pkg.crossplane.io_aws_providerconfigusages.yaml
+++ b/crossplane/meta-crds/providerconfigs-crds/pkg.crossplane.io_aws_providerconfigusages.yaml
@@ -1,0 +1,100 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.0
+  name: providerconfigusages.aws.crossplane.io
+spec:
+  conversion:
+    strategy: None
+  group: aws.crossplane.io
+  names:
+    categories:
+    - crossplane
+    - provider
+    - aws
+    kind: ProviderConfigUsage
+    listKind: ProviderConfigUsageList
+    plural: providerconfigusages
+    singular: providerconfigusage
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    - jsonPath: .providerConfigRef.name
+      name: CONFIG-NAME
+      type: string
+    - jsonPath: .resourceRef.kind
+      name: RESOURCE-KIND
+      type: string
+    - jsonPath: .resourceRef.name
+      name: RESOURCE-NAME
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: A ProviderConfigUsage indicates that a resource is using a ProviderConfig.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          providerConfigRef:
+            description: ProviderConfigReference to the provider config being used.
+            properties:
+              name:
+                description: Name of the referenced object.
+                type: string
+            required:
+            - name
+            type: object
+          resourceRef:
+            description: ResourceReference to the managed resource using the provider
+              config.
+            properties:
+              apiVersion:
+                description: APIVersion of the referenced object.
+                type: string
+              kind:
+                description: Kind of the referenced object.
+                type: string
+              name:
+                description: Name of the referenced object.
+                type: string
+              uid:
+                description: UID of the referenced object.
+                type: string
+            required:
+            - apiVersion
+            - kind
+            - name
+            type: object
+        required:
+        - providerConfigRef
+        - resourceRef
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+status:
+  acceptedNames:
+    categories:
+    - crossplane
+    - provider
+    - aws
+    kind: ProviderConfigUsage
+    listKind: ProviderConfigUsageList
+    plural: providerconfigusages
+    singular: providerconfigusage
+  storedVersions:
+  - v1beta1


### PR DESCRIPTION
@037g @pfischer8989   The crossplane installation was missing two meta-CRDs.  I've added these in and captured the setup changes in the README.  Crossplane end-to-end install in the README was validated on fresh GKE cluster