### PR TITLE
Change order of crossplane meta-CRD install

### DIFF
--- a/crossplane/README.md
+++ b/crossplane/README.md
@@ -5,8 +5,7 @@
 ```
 kubectl create ns crossplane-system
 kubectl -n crossplane-system apply -f meta-crds/
-kubectl -n crossplane-system apply -f crossplane-v0.14.0.yaml -f meta-crds/providerconfigs-crds
-
+kubectl -n crossplane-system apply  -f meta-crds/providerconfigs-crds -f crossplane-v0.14.0.yaml
 ```
 
 ##### 2) Install crossplane AWS secret


### PR DESCRIPTION
The crossplane operator installation needs to occur after the providrconfig meta-CRDs installed otherwise a bizarre apiVersion mismatch error is thrown.